### PR TITLE
Fix metrics with `tendermint_` namespace

### DIFF
--- a/modules/metric_ingestor/custom_checks/chain_metadata.py
+++ b/modules/metric_ingestor/custom_checks/chain_metadata.py
@@ -18,7 +18,7 @@ from datadog_checks.base import AgentCheck
 
 
 MONIKERS_FILE = "/tmp/monikers.json"
-ACTIVE_SET_SIZE = 60
+ACTIVE_SET_SIZE = 50
 
 
 @dataclass

--- a/modules/metric_ingestor/ec2.tf
+++ b/modules/metric_ingestor/ec2.tf
@@ -95,7 +95,7 @@ data "cloudinit_config" "init" {
             }
             instances = [
               {
-                base_api_url               = var.chain_metadata_node_base_url
+                base_api_url              = var.chain_metadata_node_base_url
                 addresses_sharing_metrics = [for v in var.validators : v.address]
               }
             ]

--- a/modules/metric_ingestor/ec2.tf
+++ b/modules/metric_ingestor/ec2.tf
@@ -57,9 +57,11 @@ data "cloudinit_config" "init" {
             }
             instances = [
               for validator in var.validators : {
+                # NOTE: The 'metrics' field is intentionally omitted to allow custom transformers
+                # in the Datadog OpenMetrics check to process and rename metrics.
+                # See: https://docs.datadoghq.com/developers/custom_checks/prometheus/
                 openmetrics_endpoint = validator.openmetrics_endpoint
                 namespace            = var.metrics_namespace
-                metrics              = var.metrics
                 max_returned_metrics = var.max_returned_metrics
                 address              = validator.address
                 machine_id           = validator.machine_id

--- a/modules/metric_ingestor/variables.tf
+++ b/modules/metric_ingestor/variables.tf
@@ -64,20 +64,6 @@ variable "validators" {
   description = "List of validators for which to collect metrics"
 }
 
-variable "metrics" {
-  type        = list(string)
-  description = <<-EOT
-    The list of metrics to track.
-    Cosmos Telemetry and go-metrics support some metrics out of the box:
-      https://docs.cosmos.network/master/core/telemetry.html
-      https://github.com/armon/go-metrics/blob/master/metrics.go#L242
-    Custom metrics for dYdX protocol are usually in the form of <module>.*
-  EOT
-  default = [
-    ".*"
-  ]
-}
-
 variable "max_returned_metrics" {
   type        = number
   description = "the number of metrics we allow `com.datadoghq.ad.instances` to return."


### PR DESCRIPTION
* fix `ACTIVE_SET_SIZE` variable - correct value is 50
* add a transformer to all scrapers that renames metrics starting with `tendermint_` to `cometbft_`
* remove `metrics: .*` from the yaml config, so that the custom transformer can be invoked 