### PR TITLE
Fix metrics with `tendermint_` namespace

### DIFF
--- a/modules/metric_ingestor/custom_checks/chain_metadata.py
+++ b/modules/metric_ingestor/custom_checks/chain_metadata.py
@@ -18,7 +18,7 @@ from datadog_checks.base import AgentCheck
 
 
 MONIKERS_FILE = "/tmp/monikers.json"
-ACTIVE_SET_SIZE = 60
+ACTIVE_SET_SIZE = 50
 
 
 @dataclass

--- a/modules/metric_ingestor/custom_checks/validator_metrics.py
+++ b/modules/metric_ingestor/custom_checks/validator_metrics.py
@@ -20,18 +20,18 @@ class ValidatorMetricsCheck(OpenMetricsBaseCheckV2):
         for scraper in self.scrapers.values():
             global_options = scraper.metric_transformer.global_options
             scraper.metric_transformer.add_custom_transformer(
-                r'^tendermint_(.*)$',
+                r".*",
                 # we need the global_options for the scraper to be available in the transformer
-                lambda metric, sample_data, runtime_data, global_options=global_options: self.rename_tendermint_metric(
+                lambda metric, sample_data, runtime_data, global_options=global_options: self.custom_metric_transformer(
                     metric, sample_data, runtime_data, global_options
                 ),
                 pattern=True
             )
 
-    def rename_tendermint_metric(self, metric, sample_data, runtime_data, global_options):
-        # Rename tendermint_* metrics to cometbft_*
-        metric.name = 'cometbft_' + metric.name[len('tendermint_'):]
-
+    def custom_metric_transformer(self, metric, sample_data, runtime_data, global_options):
+        if metric.name.startswith("tendermint_"):
+            metric.name = "cometbft_" + metric.name[len("tendermint_"):]
+        # Always submit the metric, using the native transformer
         transformer = get_native_dynamic_transformer(self, metric.name, {}, global_options)
         transformer(metric, sample_data, runtime_data)
 

--- a/modules/metric_ingestor/custom_checks/validator_metrics.py
+++ b/modules/metric_ingestor/custom_checks/validator_metrics.py
@@ -48,7 +48,12 @@ class ValidatorMetricsCheck(OpenMetricsBaseCheckV2):
         try:
             super().check(instance)
         except Exception as e:
-            self.log.error("Error checking instance: %s", e)
+            self.log.error(
+                "Error checking instance: %s | address: %s | machine_id: %s",
+                e,
+                instance.get("address"),
+                instance.get("machine_id"),
+            )
             is_reachable = 0
         else:
             is_reachable = 1

--- a/modules/metric_ingestor/ec2.tf
+++ b/modules/metric_ingestor/ec2.tf
@@ -95,7 +95,7 @@ data "cloudinit_config" "init" {
             }
             instances = [
               {
-                base_api_url               = var.chain_metadata_node_base_url
+                base_api_url              = var.chain_metadata_node_base_url
                 addresses_sharing_metrics = [for v in var.validators : v.address]
               }
             ]

--- a/modules/metric_ingestor/ec2.tf
+++ b/modules/metric_ingestor/ec2.tf
@@ -57,9 +57,11 @@ data "cloudinit_config" "init" {
             }
             instances = [
               for validator in var.validators : {
+                # NOTE: The 'metrics' field is intentionally omitted to allow custom transformers
+                # in the Datadog OpenMetrics check to process and rename metrics.
+                # See: https://docs.datadoghq.com/developers/custom_checks/prometheus/
                 openmetrics_endpoint = validator.openmetrics_endpoint
                 namespace            = var.metrics_namespace
-                metrics              = var.metrics
                 max_returned_metrics = var.max_returned_metrics
                 address              = validator.address
                 machine_id           = validator.machine_id

--- a/modules/metric_ingestor/variables.tf
+++ b/modules/metric_ingestor/variables.tf
@@ -64,20 +64,6 @@ variable "validators" {
   description = "List of validators for which to collect metrics"
 }
 
-variable "metrics" {
-  type        = list(string)
-  description = <<-EOT
-    The list of metrics to track.
-    Cosmos Telemetry and go-metrics support some metrics out of the box:
-      https://docs.cosmos.network/master/core/telemetry.html
-      https://github.com/armon/go-metrics/blob/master/metrics.go#L242
-    Custom metrics for dYdX protocol are usually in the form of <module>.*
-  EOT
-  default = [
-    ".*"
-  ]
-}
-
 variable "max_returned_metrics" {
   type        = number
   description = "the number of metrics we allow `com.datadoghq.ad.instances` to return."


### PR DESCRIPTION
- fix ACTIVE_SET_SIZE variable - correct value is 50
- add a transformer to all scrapers that renames metrics starting with tendermint_ to cometbft_
- remove metrics: .* from the yaml config, so that the custom transformer can be invoked
- add debug information related to instance details when an instance check fails